### PR TITLE
Use ExtractTextPlugin for css imports

### DIFF
--- a/src/builder/webpack-rules.js
+++ b/src/builder/webpack-rules.js
@@ -33,11 +33,13 @@ module.exports = function() {
     // CSS Compilation.
     rules.push({
         test: /\.css$/,
-
         exclude: Config.preprocessors.postCss
             ? Config.preprocessors.postCss.map(postCss => postCss.src.path())
             : [],
-        loaders: ['style-loader', 'css-loader']
+        use: ExtractTextPlugin.extract({
+            fallback: "style-loader",
+            use: "css-loader"
+        })
     });
 
     // Recognize .scss Imports.


### PR DESCRIPTION
Always use ExtractTextPlugin for /\.css$/ to prevent delayed loading of .css files when imported with webpack.

Example: [https://i.imgur.com/c3ULh6A.gif](https://i.imgur.com/c3ULh6A.gif)